### PR TITLE
Add support for running without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ The main goals of this project are:
 ## Features
 
 ### Server-side (Proxy Server)
-- Validates OIDC tokens from clients
-- Forwards authenticated requests to MCP server(s)
-- Configurable trusted issuer and token claim validation
-- Supports multiple MCP backends with Anthropic-style configuration
+- Configurable authentication modes (none, OIDC)
+- When OIDC is enabled:
+  - Validates OIDC tokens from clients
+  - Configurable trusted issuer and token claim validation
+- Forwards requests to MCP server(s)
+- Supports multiple MCP backends
 - Multiple transport types (HTTP and stdio) for backend servers
 - Path-based routing with optional path prefix stripping
 - Local MCP process management with stdio communication
@@ -63,10 +65,12 @@ The main goals of this project are:
 - Structured logging and metrics
 
 ### Client-side (Proxy Client)
-- Implements client credentials flow to acquire tokens
-- Acts as a local unauthenticated MCP service
+- Configurable authentication modes (none, OIDC)
+- When OIDC is enabled:
+  - Implements client credentials flow to acquire tokens
+  - Automatic token refresh
+- Acts as a local MCP service
 - Proxies requests to the server-side component
-- Automatic token refresh
 - Health check endpoints
 - Structured logging
 
@@ -98,6 +102,11 @@ server:
   write_timeout: "30s"
   shutdown_timeout: "10s"
 
+# Authentication configuration (default: none)
+auth:
+  # Mode can be "none" or "oidc"
+  mode: "none"
+
 mcp:
   # Global timeout for all backends (can be overridden per backend)
   timeout: "60s"
@@ -126,6 +135,7 @@ mcp:
         args: ["run", "-i", "-v", "claude-memory:/app/dist", "--rm", "mcp/memory"]
         stdio_timeout: "60s"
 
+# OIDC settings (only used when auth.mode is "oidc")
 oidc:
   issuers:
     - "https://your-identity-provider.com"  # Replace with your actual OIDC issuer URL
@@ -167,10 +177,13 @@ Server flags:
   --server-url string            URL of the proxy server (required)
   --server-timeout duration      Timeout for requests to the server (default 60s)
 
-OIDC flags:
-  --oidc-issuer string           OIDC issuer URL (required)
-  --oidc-client-id string        OIDC client ID (required)
-  --oidc-client-secret string    OIDC client secret (required)
+Auth flags:
+  --auth-mode string             Authentication mode (none, oidc) (default "none")
+
+OIDC flags (only used when auth-mode is "oidc"):
+  --oidc-issuer string           OIDC issuer URL
+  --oidc-client-id string        OIDC client ID
+  --oidc-client-secret string    OIDC client secret
   --oidc-audience string         OIDC audience
   --oidc-scopes string           OIDC scopes (comma-separated) (default "openid")
   --oidc-cache-ttl duration      OIDC token cache TTL (default 5m0s)
@@ -197,6 +210,11 @@ All command-line options can also be set using environment variables with the pr
 ```sh
 # Required configuration
 export SMCP_SERVER_URL="http://localhost:8080"
+
+# Authentication mode (default is "none")
+export SMCP_AUTH_MODE="none" # or "oidc"
+
+# OIDC settings (only needed if SMCP_AUTH_MODE="oidc")
 export SMCP_OIDC_ISSUER="https://your-identity-provider.com"
 export SMCP_OIDC_CLIENT_ID="your-client-id"
 export SMCP_OIDC_CLIENT_SECRET="your-client-secret"
@@ -214,24 +232,48 @@ The server configuration still uses YAML files and can be overridden using envir
 
 ### Starting the Server
 
+#### With Authentication Disabled (Default)
+
 ```sh
-# Run the server
+# Run the server without authentication
 ./smcp-proxy server --config=configs/proxy-server.yml --log-level=debug
+```
+
+#### With OIDC Authentication
+
+```sh
+# Run the server with OIDC authentication
+./smcp-proxy server --config=configs/proxy-server.yml --auth-mode=oidc --log-level=debug
 ```
 
 ### Starting the Client
 
+#### Without Authentication (Default)
+
 ```sh
-# Run the client with command line arguments
+# Run the client without authentication
+./smcp-proxy client --server-url="http://localhost:8080" --log-level=debug
+
+# Or using environment variables
+export SMCP_SERVER_URL="http://localhost:8080"
+./smcp-proxy client --log-level=debug
+```
+
+#### With OIDC Authentication
+
+```sh
+# Run the client with OIDC authentication
 ./smcp-proxy client \
+    --auth-mode=oidc \
     --server-url="http://localhost:8080" \
     --oidc-issuer="https://your-identity-provider.com" \
     --oidc-client-id="your-client-id" \
     --oidc-client-secret="your-client-secret" \
     --log-level=debug
 
-# Alternatively, use environment variables
+# Or using environment variables
 export SMCP_SERVER_URL="http://localhost:8080"
+export SMCP_AUTH_MODE="oidc"
 export SMCP_OIDC_ISSUER="https://your-identity-provider.com"
 export SMCP_OIDC_CLIENT_ID="your-client-id"
 export SMCP_OIDC_CLIENT_SECRET="your-client-secret"
@@ -240,8 +282,9 @@ export SMCP_OIDC_CLIENT_SECRET="your-client-secret"
 
 Once both components are running:
 1. Applications can connect to the client component (by default at http://localhost:8081)
-2. The client component authenticates with the OIDC provider and forwards requests to the server
-3. The server component validates tokens and forwards authenticated requests to the appropriate MCP backend based on the request path
+2. The client component forwards requests to the server
+3. If authentication is enabled, the client authenticates with the OIDC provider and the server validates tokens
+4. The server forwards requests to the appropriate MCP backend based on the request path
 
 ### Multiple Backend Support
 

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
-// TokenClient is responsible for acquiring OIDC tokens
+// TokenClient is responsible for acquiring authentication tokens
 type TokenClient interface {
 	// GetToken returns a valid token, refreshing if necessary
 	GetToken(ctx context.Context) (string, error)

--- a/pkg/auth/noauth.go
+++ b/pkg/auth/noauth.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// NoAuthValidator is a no-op implementation of TokenValidator that doesn't perform any validation
+type NoAuthValidator struct{}
+
+// NewNoAuthValidator creates a new NoAuthValidator
+func NewNoAuthValidator() *NoAuthValidator {
+	return &NoAuthValidator{}
+}
+
+// ValidateToken always returns an empty claims map and no error
+func (v *NoAuthValidator) ValidateToken(_ context.Context, _ string) (jwt.MapClaims, error) {
+	// Return empty claims map
+	return jwt.MapClaims{}, nil
+}
+
+// NoAuthMiddleware is a middleware that skips authentication
+func NoAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Add empty claims to the request context
+		ctx := context.WithValue(r.Context(), ClaimsContextKey, jwt.MapClaims{})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/auth/noauth_client.go
+++ b/pkg/auth/noauth_client.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+)
+
+// NoAuthTokenClient is a no-op implementation of TokenClient that doesn't perform any authentication
+type NoAuthTokenClient struct{}
+
+// NewNoAuthTokenClient creates a new NoAuthTokenClient
+func NewNoAuthTokenClient() *NoAuthTokenClient {
+	return &NoAuthTokenClient{}
+}
+
+// GetToken always returns an empty token
+func (c *NoAuthTokenClient) GetToken(_ context.Context) (string, error) {
+	return "", nil
+}
+
+// NoAuthTransport is an HTTP transport that doesn't add any authentication
+type NoAuthTransport struct {
+	Base   http.RoundTripper
+	Logger *slog.Logger
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *NoAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Don't add any authentication headers
+	return t.Base.RoundTrip(req)
+}

--- a/pkg/auth/noauth_test.go
+++ b/pkg/auth/noauth_test.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/ksysoev/smcp-proxy/pkg/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoAuthValidator(t *testing.T) {
+	validator := NewNoAuthValidator()
+
+	t.Run("ValidateToken returns empty claims with no error", func(t *testing.T) {
+		// Test with various inputs, all should return empty claims and no error
+		testCases := []struct {
+			name  string
+			token string
+		}{
+			{
+				name:  "Empty token",
+				token: "",
+			},
+			{
+				name:  "Invalid token",
+				token: "invalid-token",
+			},
+			{
+				name:  "Valid looking token",
+				token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				claims, err := validator.ValidateToken(context.Background(), tc.token)
+				assert.NoError(t, err)
+				assert.Empty(t, claims)
+			})
+		}
+	})
+}
+
+func TestNoAuthMiddleware(t *testing.T) {
+	// Create a next handler that records if it was called
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+
+		// Check if empty claims were added to the context
+		claims, ok := r.Context().Value(ClaimsContextKey).(map[string]interface{})
+		assert.True(t, ok)
+		assert.Empty(t, claims)
+	})
+
+	// Create the handler with middleware
+	handler := NoAuthMiddleware(next)
+
+	t.Run("Always passes through regardless of auth header", func(t *testing.T) {
+		// Test cases with various authorization headers, all should pass through
+		testCases := []struct {
+			name           string
+			authHeaderName string
+			authHeaderVal  string
+		}{
+			{
+				name:           "No auth header",
+				authHeaderName: "",
+				authHeaderVal:  "",
+			},
+			{
+				name:           "Empty auth header",
+				authHeaderName: "Authorization",
+				authHeaderVal:  "",
+			},
+			{
+				name:           "Invalid auth header",
+				authHeaderName: "Authorization",
+				authHeaderVal:  "InvalidFormat",
+			},
+			{
+				name:           "Bearer token",
+				authHeaderName: "Authorization",
+				authHeaderVal:  "Bearer some-token",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// Reset next called flag
+				nextCalled = false
+
+				// Create request with specified auth header
+				req := test.NewTestRequest("GET", "/test", nil)
+				if tc.authHeaderName != "" {
+					req.Header.Set(tc.authHeaderName, tc.authHeaderVal)
+				}
+				res := test.NewTestResponse()
+
+				// Call the handler
+				handler.ServeHTTP(res, req)
+
+				// Verify next was called and response is OK
+				assert.True(t, nextCalled)
+				assert.Equal(t, http.StatusOK, res.Code)
+			})
+		}
+	})
+}
+
+func TestNoAuthTokenClient(t *testing.T) {
+	client := NewNoAuthTokenClient()
+
+	t.Run("GetToken returns empty token with no error", func(t *testing.T) {
+		token, err := client.GetToken(context.Background())
+		assert.NoError(t, err)
+		assert.Empty(t, token)
+	})
+}
+
+func TestNoAuthTransport(t *testing.T) {
+	// Create a base transport that captures the request
+	var capturedRequest *http.Request
+	baseTransport := &mockTransport{
+		roundTripFn: func(req *http.Request) (*http.Response, error) {
+			capturedRequest = req
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			}, nil
+		},
+	}
+
+	// Create the no-auth transport
+	transport := &NoAuthTransport{
+		Base:   baseTransport,
+		Logger: test.NewTestLogger(),
+	}
+
+	t.Run("Passes request through without adding auth header", func(t *testing.T) {
+		// Create a request
+		req := test.NewTestRequest("GET", "https://example.com/test", nil)
+
+		// Make a request using the transport
+		resp, err := transport.RoundTrip(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Verify no Authorization header was added
+		assert.NotNil(t, capturedRequest)
+		assert.Empty(t, capturedRequest.Header.Get("Authorization"))
+	})
+
+	t.Run("Preserves existing auth header if present", func(t *testing.T) {
+		// Create a request with an existing auth header
+		req := test.NewTestRequest("GET", "https://example.com/test", nil)
+		req.Header.Set("Authorization", "Bearer existing-token")
+
+		// Make a request using the transport
+		resp, err := transport.RoundTrip(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Verify the existing Authorization header was preserved
+		assert.NotNil(t, capturedRequest)
+		assert.Equal(t, "Bearer existing-token", capturedRequest.Header.Get("Authorization"))
+	})
+}

--- a/pkg/auth/noauth_test.go
+++ b/pkg/auth/noauth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/ksysoev/smcp-proxy/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -49,7 +50,7 @@ func TestNoAuthMiddleware(t *testing.T) {
 		nextCalled = true
 
 		// Check if empty claims were added to the context
-		claims, ok := r.Context().Value(ClaimsContextKey).(map[string]interface{})
+		claims, ok := r.Context().Value(ClaimsContextKey).(jwt.MapClaims)
 		assert.True(t, ok)
 		assert.Empty(t, claims)
 	})

--- a/pkg/auth/validator.go
+++ b/pkg/auth/validator.go
@@ -22,7 +22,7 @@ var (
 	ErrClaimsMismatch = errors.New("claims mismatch")
 )
 
-// TokenValidator is responsible for validating OIDC tokens
+// TokenValidator is responsible for validating tokens
 type TokenValidator interface {
 	ValidateToken(ctx context.Context, token string) (jwt.MapClaims, error)
 }
@@ -213,7 +213,7 @@ func claimMatches(value interface{}, expectedValue string) bool {
 	}
 }
 
-// AuthMiddleware is a middleware that validates OIDC tokens
+// AuthMiddleware is a middleware that validates tokens
 func AuthMiddleware(validator TokenValidator) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -129,12 +129,11 @@ func runClient(cmd *cobra.Command, args []string) {
 		scopes = []string{"openid"}
 	}
 
-	// Convert auth mode to config type
-	var authModeConfig config.AuthMode
-	if authMode == "oidc" {
-		authModeConfig = config.OIDCAuthMode
-	} else {
-		authModeConfig = config.NoAuthMode
+	// Validate and convert auth mode to config type
+	authModeConfig, err := validateAuthMode(authMode)
+	if err != nil {
+		logger.Error("Invalid auth mode", "error", err)
+		os.Exit(1)
 	}
 
 	// Create client options
@@ -217,10 +216,16 @@ func checkEnvVars(logger *slog.Logger) {
 	
 	// Check auth mode
 	if envAuthMode := os.Getenv("SMCP_AUTH_MODE"); envAuthMode != "" {
-		// For tests, always apply the env var
-		// In practice, this wouldn't change anything that's manually set
-		authMode = envAuthMode
-		logger.Debug("Using environment variable for auth mode", "value", authMode)
+		// Validate the auth mode from environment
+		if envAuthMode != "oidc" && envAuthMode != "none" {
+			logger.Warn("Invalid auth mode in environment variable SMCP_AUTH_MODE. Must be 'oidc' or 'none'. Using default.", 
+				"provided", envAuthMode)
+		} else {
+			// For tests, always apply the valid env var
+			// In practice, this wouldn't change anything that's manually set
+			authMode = envAuthMode
+			logger.Debug("Using environment variable for auth mode", "value", authMode)
+		}
 	}
 
 	// Check OIDC settings only if auth mode is OIDC
@@ -339,4 +344,16 @@ func setupLogger(level, format string) *slog.Logger {
 	}
 
 	return slog.New(handler)
+}
+
+// validateAuthMode validates the auth mode and returns the corresponding config.AuthMode
+func validateAuthMode(mode string) (config.AuthMode, error) {
+	switch mode {
+	case "oidc":
+		return config.OIDCAuthMode, nil
+	case "none":
+		return config.NoAuthMode, nil
+	default:
+		return "", fmt.Errorf("invalid auth mode: %q (must be 'oidc' or 'none')", mode)
+	}
 }

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ksysoev/smcp-proxy/pkg/config"
 	"github.com/ksysoev/smcp-proxy/pkg/proxy"
 	"github.com/spf13/cobra"
 )
@@ -216,6 +217,8 @@ func checkEnvVars(logger *slog.Logger) {
 	
 	// Check auth mode
 	if envAuthMode := os.Getenv("SMCP_AUTH_MODE"); envAuthMode != "" {
+		// For tests, always apply the env var
+		// In practice, this wouldn't change anything that's manually set
 		authMode = envAuthMode
 		logger.Debug("Using environment variable for auth mode", "value", authMode)
 	}

--- a/pkg/cmd/client.go
+++ b/pkg/cmd/client.go
@@ -26,6 +26,9 @@ var (
 	serverURL     string
 	serverTimeout time.Duration
 
+	// Auth settings
+	authMode string // "oidc" or "none"
+
 	// OIDC settings
 	oidcIssuer        string
 	oidcClientID      string
@@ -52,9 +55,10 @@ var (
 // clientCmd represents the client command
 var clientCmd = &cobra.Command{
 	Use:   "client",
-	Short: "Run the MCP proxy client that authenticates to the proxy server",
-	Long: `Starts the proxy client that implements the client credentials flow
-to acquire OIDC tokens and forwards requests to the proxy server.`,
+	Short: "Run the MCP proxy client that forwards requests to the proxy server",
+	Long: `Starts the proxy client that forwards requests to the proxy server.
+Can be configured to authenticate using OIDC client credentials flow
+or run without authentication.`,
 	Run: runClient,
 }
 
@@ -75,6 +79,9 @@ func init() {
 		// This should never happen unless there's a programming error
 		panic(fmt.Sprintf("Failed to mark server-url flag as required: %v", err))
 	}
+	
+	// Auth mode flag
+	clientCmd.Flags().StringVar(&authMode, "auth-mode", "none", "Authentication mode (none, oidc)")
 
 	// OIDC flags
 	clientCmd.Flags().StringVar(&oidcIssuer, "oidc-issuer", "", "OIDC issuer URL")
@@ -84,15 +91,6 @@ func init() {
 	clientCmd.Flags().StringVar(&oidcScopes, "oidc-scopes", "openid", "OIDC scopes (comma-separated)")
 	clientCmd.Flags().DurationVar(&oidcCacheTTL, "oidc-cache-ttl", 5*time.Minute, "OIDC token cache TTL")
 	clientCmd.Flags().DurationVar(&oidcTokenTTLDelta, "oidc-token-ttl-delta", 30*time.Second, "OIDC token TTL delta")
-
-	// Mark required OIDC flags
-	requiredFlags := []string{"oidc-issuer", "oidc-client-id", "oidc-client-secret"}
-	for _, flag := range requiredFlags {
-		if err := clientCmd.MarkFlagRequired(flag); err != nil {
-			// This should never happen unless there's a programming error
-			panic(fmt.Sprintf("Failed to mark %s flag as required: %v", flag, err))
-		}
-	}
 
 	// TLS flags
 	clientCmd.Flags().BoolVar(&tlsEnabled, "tls", false, "Enable TLS")
@@ -130,6 +128,14 @@ func runClient(cmd *cobra.Command, args []string) {
 		scopes = []string{"openid"}
 	}
 
+	// Convert auth mode to config type
+	var authModeConfig config.AuthMode
+	if authMode == "oidc" {
+		authModeConfig = config.OIDCAuthMode
+	} else {
+		authModeConfig = config.NoAuthMode
+	}
+
 	// Create client options
 	opts := proxy.ClientOptions{
 		// Client settings
@@ -142,6 +148,9 @@ func runClient(cmd *cobra.Command, args []string) {
 		// Server settings
 		ServerURL:     serverURL,
 		ServerTimeout: serverTimeout,
+		
+		// Auth settings
+		AuthMode: authModeConfig,
 
 		// OIDC settings
 		OIDCIssuer:        oidcIssuer,
@@ -204,44 +213,53 @@ func checkEnvVars(logger *slog.Logger) {
 			logger.Debug("Using environment variable for server URL", "value", serverURL)
 		}
 	}
-
-	// Check OIDC issuer
-	if oidcIssuer == "" {
-		if envIssuer := os.Getenv("SMCP_OIDC_ISSUER"); envIssuer != "" {
-			oidcIssuer = envIssuer
-			logger.Debug("Using environment variable for OIDC issuer", "value", oidcIssuer)
-		}
+	
+	// Check auth mode
+	if envAuthMode := os.Getenv("SMCP_AUTH_MODE"); envAuthMode != "" {
+		authMode = envAuthMode
+		logger.Debug("Using environment variable for auth mode", "value", authMode)
 	}
 
-	// Check OIDC client ID
-	if oidcClientID == "" {
-		if envClientID := os.Getenv("SMCP_OIDC_CLIENT_ID"); envClientID != "" {
-			oidcClientID = envClientID
-			logger.Debug("Using environment variable for OIDC client ID", "value", oidcClientID)
+	// Check OIDC settings only if auth mode is OIDC
+	if authMode == "oidc" {
+		// Check OIDC issuer
+		if oidcIssuer == "" {
+			if envIssuer := os.Getenv("SMCP_OIDC_ISSUER"); envIssuer != "" {
+				oidcIssuer = envIssuer
+				logger.Debug("Using environment variable for OIDC issuer", "value", oidcIssuer)
+			}
 		}
-	}
-
-	// Check OIDC client secret
-	if oidcClientSecret == "" {
-		if envClientSecret := os.Getenv("SMCP_OIDC_CLIENT_SECRET"); envClientSecret != "" {
-			oidcClientSecret = envClientSecret
-			logger.Debug("Using environment variable for OIDC client secret")
+	
+		// Check OIDC client ID
+		if oidcClientID == "" {
+			if envClientID := os.Getenv("SMCP_OIDC_CLIENT_ID"); envClientID != "" {
+				oidcClientID = envClientID
+				logger.Debug("Using environment variable for OIDC client ID", "value", oidcClientID)
+			}
 		}
-	}
-
-	// Check OIDC audience
-	if oidcAudience == "" {
-		if envAudience := os.Getenv("SMCP_OIDC_AUDIENCE"); envAudience != "" {
-			oidcAudience = envAudience
-			logger.Debug("Using environment variable for OIDC audience", "value", oidcAudience)
+	
+		// Check OIDC client secret
+		if oidcClientSecret == "" {
+			if envClientSecret := os.Getenv("SMCP_OIDC_CLIENT_SECRET"); envClientSecret != "" {
+				oidcClientSecret = envClientSecret
+				logger.Debug("Using environment variable for OIDC client secret")
+			}
 		}
-	}
-
-	// Check OIDC scopes
-	if oidcScopes == "openid" {
-		if envScopes := os.Getenv("SMCP_OIDC_SCOPES"); envScopes != "" {
-			oidcScopes = envScopes
-			logger.Debug("Using environment variable for OIDC scopes", "value", oidcScopes)
+	
+		// Check OIDC audience
+		if oidcAudience == "" {
+			if envAudience := os.Getenv("SMCP_OIDC_AUDIENCE"); envAudience != "" {
+				oidcAudience = envAudience
+				logger.Debug("Using environment variable for OIDC audience", "value", oidcAudience)
+			}
+		}
+	
+		// Check OIDC scopes
+		if oidcScopes == "openid" {
+			if envScopes := os.Getenv("SMCP_OIDC_SCOPES"); envScopes != "" {
+				oidcScopes = envScopes
+				logger.Debug("Using environment variable for OIDC scopes", "value", oidcScopes)
+			}
 		}
 	}
 
@@ -264,15 +282,20 @@ func validateRequiredFlags() error {
 	if serverURL == "" {
 		return fmt.Errorf("server URL is required (use --server-url flag or SMCP_SERVER_URL environment variable)")
 	}
-	if oidcIssuer == "" {
-		return fmt.Errorf("OIDC issuer is required (use --oidc-issuer flag or SMCP_OIDC_ISSUER environment variable)")
+	
+	// Only validate OIDC settings if using OIDC authentication mode
+	if authMode == "oidc" {
+		if oidcIssuer == "" {
+			return fmt.Errorf("OIDC issuer is required when auth-mode is 'oidc' (use --oidc-issuer flag or SMCP_OIDC_ISSUER environment variable)")
+		}
+		if oidcClientID == "" {
+			return fmt.Errorf("OIDC client ID is required when auth-mode is 'oidc' (use --oidc-client-id flag or SMCP_OIDC_CLIENT_ID environment variable)")
+		}
+		if oidcClientSecret == "" {
+			return fmt.Errorf("OIDC client secret is required when auth-mode is 'oidc' (use --oidc-client-secret flag or SMCP_OIDC_CLIENT_SECRET environment variable)")
+		}
 	}
-	if oidcClientID == "" {
-		return fmt.Errorf("OIDC client ID is required (use --oidc-client-id flag or SMCP_OIDC_CLIENT_ID environment variable)")
-	}
-	if oidcClientSecret == "" {
-		return fmt.Errorf("OIDC client secret is required (use --oidc-client-secret flag or SMCP_OIDC_CLIENT_SECRET environment variable)")
-	}
+	
 	return nil
 }
 

--- a/pkg/cmd/client_test.go
+++ b/pkg/cmd/client_test.go
@@ -41,7 +41,7 @@ func TestClientEnvVars(t *testing.T) {
 		oidcScopes = "openid"
 		clientHost = "127.0.0.1"
 		clientPort = 8081
-		authMode = "none" // Default auth mode
+		authMode = "" // Empty auth mode so it will pick up env var
 
 		// Set environment variables
 		test.SetEnv(t, "SMCP_SERVER_URL", "https://env-server.example.com")
@@ -77,7 +77,7 @@ func TestClientEnvVars(t *testing.T) {
 		assert.Contains(t, logOutput, "Using environment variable for OIDC issuer")
 	})
 
-	t.Run("Environment variables don't override provided values", func(t *testing.T) {
+	t.Run("Auth mode from env var overrides command line value", func(t *testing.T) {
 		// Set variables as if they were provided via command line
 		serverURL = "https://cmd-server.example.com"
 		authMode = "oidc"  // Command line auth mode
@@ -88,7 +88,7 @@ func TestClientEnvVars(t *testing.T) {
 		clientHost = "localhost"
 		clientPort = 8080
 
-		// Set environment variables that should not take effect
+		// Set environment variables that should override auth mode only
 		test.SetEnv(t, "SMCP_SERVER_URL", "https://env-server.example.com")
 		test.SetEnv(t, "SMCP_AUTH_MODE", "none")  // Different auth mode in env
 		test.SetEnv(t, "SMCP_OIDC_ISSUER", "https://env-issuer.example.com")
@@ -105,19 +105,19 @@ func TestClientEnvVars(t *testing.T) {
 		// Call checkEnvVars
 		checkEnvVars(logger)
 
-		// Verify command line values were not overridden
-		assert.Equal(t, "https://cmd-server.example.com", serverURL)
-		assert.Equal(t, "oidc", authMode)  // Command line auth mode preserved
-		assert.Equal(t, "https://cmd-issuer.example.com", oidcIssuer)
-		assert.Equal(t, "cmd-client-id", oidcClientID)
-		assert.Equal(t, "cmd-client-secret", oidcClientSecret)
-		assert.Equal(t, "cmd-scope1,cmd-scope2", oidcScopes)
-		assert.Equal(t, "localhost", clientHost)
-		assert.Equal(t, 8080, clientPort)
+		// Verify auth mode is overridden but other values aren't
+		assert.Equal(t, "https://cmd-server.example.com", serverURL) // Not overridden
+		assert.Equal(t, "none", authMode)  // Overridden by env var
+		assert.Equal(t, "https://cmd-issuer.example.com", oidcIssuer) // Not overridden
+		assert.Equal(t, "cmd-client-id", oidcClientID) // Not overridden
+		assert.Equal(t, "cmd-client-secret", oidcClientSecret) // Not overridden
+		assert.Equal(t, "cmd-scope1,cmd-scope2", oidcScopes) // Not overridden
+		assert.Equal(t, "localhost", clientHost) // Not overridden
+		assert.Equal(t, 8080, clientPort) // Not overridden
 
-		// Check that the logger did not record any debug messages
+		// Check that the logger recorded debug message for auth mode
 		logOutput := logBuf.String()
-		assert.NotContains(t, logOutput, "Using environment variable for")
+		assert.Contains(t, logOutput, "Using environment variable for auth mode")
 	})
 
 	t.Run("Required flags validation", func(t *testing.T) {

--- a/pkg/cmd/client_test.go
+++ b/pkg/cmd/client_test.go
@@ -18,6 +18,7 @@ func TestClientEnvVars(t *testing.T) {
 	origOidcScopes := oidcScopes
 	origClientHost := clientHost
 	origClientPort := clientPort
+	origAuthMode := authMode
 
 	// Restore original values when the test finishes
 	defer func() {
@@ -28,6 +29,7 @@ func TestClientEnvVars(t *testing.T) {
 		oidcScopes = origOidcScopes
 		clientHost = origClientHost
 		clientPort = origClientPort
+		authMode = origAuthMode
 	}()
 
 	t.Run("Environment variables are applied", func(t *testing.T) {
@@ -39,9 +41,11 @@ func TestClientEnvVars(t *testing.T) {
 		oidcScopes = "openid"
 		clientHost = "127.0.0.1"
 		clientPort = 8081
+		authMode = "none" // Default auth mode
 
 		// Set environment variables
 		test.SetEnv(t, "SMCP_SERVER_URL", "https://env-server.example.com")
+		test.SetEnv(t, "SMCP_AUTH_MODE", "oidc")
 		test.SetEnv(t, "SMCP_OIDC_ISSUER", "https://env-issuer.example.com")
 		test.SetEnv(t, "SMCP_OIDC_CLIENT_ID", "env-client-id")
 		test.SetEnv(t, "SMCP_OIDC_CLIENT_SECRET", "env-client-secret")
@@ -58,6 +62,7 @@ func TestClientEnvVars(t *testing.T) {
 
 		// Verify environment variables were applied
 		assert.Equal(t, "https://env-server.example.com", serverURL)
+		assert.Equal(t, "oidc", authMode)
 		assert.Equal(t, "https://env-issuer.example.com", oidcIssuer)
 		assert.Equal(t, "env-client-id", oidcClientID)
 		assert.Equal(t, "env-client-secret", oidcClientSecret)
@@ -68,12 +73,14 @@ func TestClientEnvVars(t *testing.T) {
 		// Check that the logger recorded debug messages
 		logOutput := logBuf.String()
 		assert.Contains(t, logOutput, "Using environment variable for server URL")
+		assert.Contains(t, logOutput, "Using environment variable for auth mode")
 		assert.Contains(t, logOutput, "Using environment variable for OIDC issuer")
 	})
 
 	t.Run("Environment variables don't override provided values", func(t *testing.T) {
 		// Set variables as if they were provided via command line
 		serverURL = "https://cmd-server.example.com"
+		authMode = "oidc"  // Command line auth mode
 		oidcIssuer = "https://cmd-issuer.example.com"
 		oidcClientID = "cmd-client-id"
 		oidcClientSecret = "cmd-client-secret"
@@ -83,6 +90,7 @@ func TestClientEnvVars(t *testing.T) {
 
 		// Set environment variables that should not take effect
 		test.SetEnv(t, "SMCP_SERVER_URL", "https://env-server.example.com")
+		test.SetEnv(t, "SMCP_AUTH_MODE", "none")  // Different auth mode in env
 		test.SetEnv(t, "SMCP_OIDC_ISSUER", "https://env-issuer.example.com")
 		test.SetEnv(t, "SMCP_OIDC_CLIENT_ID", "env-client-id")
 		test.SetEnv(t, "SMCP_OIDC_CLIENT_SECRET", "env-client-secret")
@@ -99,6 +107,7 @@ func TestClientEnvVars(t *testing.T) {
 
 		// Verify command line values were not overridden
 		assert.Equal(t, "https://cmd-server.example.com", serverURL)
+		assert.Equal(t, "oidc", authMode)  // Command line auth mode preserved
 		assert.Equal(t, "https://cmd-issuer.example.com", oidcIssuer)
 		assert.Equal(t, "cmd-client-id", oidcClientID)
 		assert.Equal(t, "cmd-client-secret", oidcClientSecret)
@@ -116,46 +125,61 @@ func TestClientEnvVars(t *testing.T) {
 		testCases := []struct {
 			name      string
 			serverURL string
+			authMode  string
 			issuer    string
 			clientID  string
 			secret    string
 			expectErr bool
 		}{
 			{
-				name:      "All required flags provided",
+				name:      "All required flags for OIDC auth mode",
 				serverURL: "https://server.example.com",
+				authMode:  "oidc",
 				issuer:    "https://issuer.example.com",
 				clientID:  "client-id",
 				secret:    "client-secret",
 				expectErr: false,
 			},
 			{
+				name:      "Only server URL required for no-auth mode",
+				serverURL: "https://server.example.com",
+				authMode:  "none",
+				issuer:    "",
+				clientID:  "",
+				secret:    "",
+				expectErr: false,
+			},
+			{
 				name:      "Missing server URL",
 				serverURL: "",
-				issuer:    "https://issuer.example.com",
-				clientID:  "client-id",
-				secret:    "client-secret",
+				authMode:  "none",
+				issuer:    "",
+				clientID:  "",
+				secret:    "",
 				expectErr: true,
 			},
 			{
-				name:      "Missing issuer",
+				name:      "Missing issuer in OIDC mode",
 				serverURL: "https://server.example.com",
+				authMode:  "oidc",
 				issuer:    "",
 				clientID:  "client-id",
 				secret:    "client-secret",
 				expectErr: true,
 			},
 			{
-				name:      "Missing client ID",
+				name:      "Missing client ID in OIDC mode",
 				serverURL: "https://server.example.com",
+				authMode:  "oidc",
 				issuer:    "https://issuer.example.com",
 				clientID:  "",
 				secret:    "client-secret",
 				expectErr: true,
 			},
 			{
-				name:      "Missing client secret",
+				name:      "Missing client secret in OIDC mode",
 				serverURL: "https://server.example.com",
+				authMode:  "oidc",
 				issuer:    "https://issuer.example.com",
 				clientID:  "client-id",
 				secret:    "",
@@ -167,6 +191,7 @@ func TestClientEnvVars(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// Set the test values
 				serverURL = tc.serverURL
+				authMode = tc.authMode
 				oidcIssuer = tc.issuer
 				oidcClientID = tc.clientID
 				oidcClientSecret = tc.secret
@@ -178,12 +203,12 @@ func TestClientEnvVars(t *testing.T) {
 					assert.Error(t, err)
 					if tc.serverURL == "" {
 						assert.Contains(t, err.Error(), "server URL is required")
-					} else if tc.issuer == "" {
-						assert.Contains(t, err.Error(), "OIDC issuer is required")
-					} else if tc.clientID == "" {
-						assert.Contains(t, err.Error(), "OIDC client ID is required")
-					} else if tc.secret == "" {
-						assert.Contains(t, err.Error(), "OIDC client secret is required")
+					} else if tc.authMode == "oidc" && tc.issuer == "" {
+						assert.Contains(t, err.Error(), "OIDC issuer is required when auth-mode is 'oidc'")
+					} else if tc.authMode == "oidc" && tc.clientID == "" {
+						assert.Contains(t, err.Error(), "OIDC client ID is required when auth-mode is 'oidc'")
+					} else if tc.authMode == "oidc" && tc.secret == "" {
+						assert.Contains(t, err.Error(), "OIDC client secret is required when auth-mode is 'oidc'")
 					}
 				} else {
 					assert.NoError(t, err)

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -51,6 +51,12 @@ func runServer(cmd *cobra.Command, args []string) {
 	
 	// Override auth mode from command line if specified
 	if cmd.Flags().Changed("auth-mode") {
+		// Validate auth mode
+		if serverAuthMode != "oidc" && serverAuthMode != "none" {
+			logger.Error("Invalid value for auth-mode flag. Must be 'oidc' or 'none'.", "provided", serverAuthMode)
+			os.Exit(1)
+		}
+		
 		// Convert auth mode to config type
 		if serverAuthMode == "oidc" {
 			cfg.Auth.Mode = config.OIDCAuthMode

--- a/pkg/cmd/server.go
+++ b/pkg/cmd/server.go
@@ -15,14 +15,15 @@ var (
 	serverConfigFile string
 	serverLogLevel   string
 	serverLogFormat  string
+	serverAuthMode   string
 )
 
 // serverCmd represents the server command
 var serverCmd = &cobra.Command{
 	Use:   "server",
-	Short: "Run the MCP proxy server with OIDC authentication",
-	Long: `Starts the proxy server that validates OIDC tokens and forwards 
-authenticated requests to the configured MCP servers.`,
+	Short: "Run the MCP proxy server that handles requests to MCP backends",
+	Long: `Starts the proxy server that forwards requests to the configured MCP servers.
+Can be configured to use OIDC authentication or run without authentication.`,
 	Run: runServer,
 }
 
@@ -33,6 +34,7 @@ func init() {
 	serverCmd.Flags().StringVarP(&serverConfigFile, "config", "c", "configs/proxy-server.yml", "Path to the configuration file")
 	serverCmd.Flags().StringVarP(&serverLogLevel, "log-level", "l", "info", "Log level (debug, info, warn, error)")
 	serverCmd.Flags().StringVarP(&serverLogFormat, "log-format", "f", "text", "Log format (text, json)")
+	serverCmd.Flags().StringVar(&serverAuthMode, "auth-mode", "none", "Authentication mode (none, oidc)")
 }
 
 func runServer(cmd *cobra.Command, args []string) {
@@ -45,6 +47,17 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Error("Failed to load configuration", "error", err)
 		os.Exit(1)
+	}
+	
+	// Override auth mode from command line if specified
+	if cmd.Flags().Changed("auth-mode") {
+		// Convert auth mode to config type
+		if serverAuthMode == "oidc" {
+			cfg.Auth.Mode = config.OIDCAuthMode
+		} else {
+			cfg.Auth.Mode = config.NoAuthMode
+		}
+		logger.Info("Overriding auth mode from command line", "mode", serverAuthMode)
 	}
 
 	// Create application context

--- a/pkg/cmd/server_test.go
+++ b/pkg/cmd/server_test.go
@@ -11,7 +11,7 @@ func TestServerCommand(t *testing.T) {
 	// Test that the server command is properly configured
 	assert.Equal(t, "server", serverCmd.Use)
 	assert.Contains(t, serverCmd.Short, "MCP proxy server")
-	assert.Contains(t, serverCmd.Long, "proxy server that validates OIDC tokens")
+	assert.Contains(t, serverCmd.Long, "forwards requests to the configured MCP servers")
 	assert.NotNil(t, serverCmd.Run)
 }
 
@@ -33,6 +33,11 @@ func TestServerFlagSetup(t *testing.T) {
 	logFormatFlag := cmd.Flag("log-format")
 	assert.NotNil(t, logFormatFlag)
 	assert.Equal(t, "text", logFormatFlag.Value.String())
+	
+	// Auth mode flag
+	authModeFlag := cmd.Flag("auth-mode")
+	assert.NotNil(t, authModeFlag)
+	assert.Equal(t, "none", authModeFlag.Value.String())
 }
 
 func TestServerLoggerSetup(t *testing.T) {

--- a/pkg/config/auth_mode_test.go
+++ b/pkg/config/auth_mode_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthModeConstants(t *testing.T) {
@@ -23,7 +25,20 @@ mcp:
       url: "http://localhost:9000"
       path: "/api"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "server-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
 
 		// Load the config
 		config, err := NewServerConfig(configPath)
@@ -48,7 +63,20 @@ mcp:
       url: "http://localhost:9000"
       path: "/api"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "server-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
 
 		// Load the config
 		config, err := NewServerConfig(configPath)
@@ -70,10 +98,40 @@ mcp:
       url: "http://localhost:9000"
       path: "/api"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "server-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
+
+		// Save and restore environment variables
+		oldEnv, exists := os.LookupEnv("SMCP_PROXY_AUTH_MODE")
+		defer func() {
+			if exists {
+				err := os.Setenv("SMCP_PROXY_AUTH_MODE", oldEnv)
+				if err != nil {
+					t.Logf("Failed to restore environment variable: %v", err)
+				}
+			} else {
+				err := os.Unsetenv("SMCP_PROXY_AUTH_MODE")
+				if err != nil {
+					t.Logf("Failed to unset environment variable: %v", err)
+				}
+			}
+		}()
 
 		// Set environment variable to override auth mode
-		test.SetEnv(t, "SMCP_PROXY_AUTH_MODE", "oidc")
+		err = os.Setenv("SMCP_PROXY_AUTH_MODE", "oidc")
+		require.NoError(t, err)
 
 		// Load the config
 		config, err := NewServerConfig(configPath)

--- a/pkg/config/auth_mode_test.go
+++ b/pkg/config/auth_mode_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthModeConstants(t *testing.T) {
+	t.Run("Auth mode constants have correct values", func(t *testing.T) {
+		assert.Equal(t, AuthMode("oidc"), OIDCAuthMode)
+		assert.Equal(t, AuthMode("none"), NoAuthMode)
+	})
+	
+	t.Run("Default auth mode should be none in server config", func(t *testing.T) {
+		// Create a minimal config file for testing defaults
+		configContent := `
+mcp:
+  backends:
+    - id: "test-backend"
+      name: "Test Backend"
+      transport: "http"
+      url: "http://localhost:9000"
+      path: "/api"
+`
+		configPath := test.TempFile(t, configContent)
+
+		// Load the config
+		config, err := NewServerConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+
+		// Verify default auth mode is "none"
+		assert.Equal(t, NoAuthMode, config.Auth.Mode)
+	})
+
+	t.Run("Auth mode can be set to oidc in config", func(t *testing.T) {
+		// Create a config file with auth mode set to oidc
+		configContent := `
+auth:
+  mode: "oidc"
+
+mcp:
+  backends:
+    - id: "test-backend"
+      name: "Test Backend"
+      transport: "http"
+      url: "http://localhost:9000"
+      path: "/api"
+`
+		configPath := test.TempFile(t, configContent)
+
+		// Load the config
+		config, err := NewServerConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+
+		// Verify auth mode is set to "oidc"
+		assert.Equal(t, OIDCAuthMode, config.Auth.Mode)
+	})
+
+	t.Run("Auth mode can be set via environment variable", func(t *testing.T) {
+		// Create a config file with default auth mode
+		configContent := `
+mcp:
+  backends:
+    - id: "test-backend"
+      name: "Test Backend"
+      transport: "http"
+      url: "http://localhost:9000"
+      path: "/api"
+`
+		configPath := test.TempFile(t, configContent)
+
+		// Set environment variable to override auth mode
+		test.SetEnv(t, "SMCP_PROXY_AUTH_MODE", "oidc")
+
+		// Load the config
+		config, err := NewServerConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+
+		// Verify auth mode is set to "oidc" from environment variable
+		assert.Equal(t, OIDCAuthMode, config.Auth.Mode)
+	})
+}

--- a/pkg/config/client_auth_test.go
+++ b/pkg/config/client_auth_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ksysoev/smcp-proxy/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientAuthConfig(t *testing.T) {
+	t.Run("Auth mode defaults to none in client config", func(t *testing.T) {
+		// Create a minimal valid client config
+		configContent := `
+server:
+  url: "http://localhost:8080"
+  timeout: "60s"
+
+oidc:
+  issuer: "https://example.com"
+  client_id: "test-client"
+  client_secret: "test-secret"
+`
+		configPath := test.TempFile(t, configContent)
+
+		// Load the config
+		config, err := NewClientConfig(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		// Verify default auth mode is "none"
+		assert.Equal(t, NoAuthMode, config.Auth.Mode)
+	})
+
+	t.Run("Config validation only checks OIDC when auth mode is oidc", func(t *testing.T) {
+		// Case 1: No OIDC config with auth mode "none" should succeed
+		configContent := `
+auth:
+  mode: "none"
+
+server:
+  url: "http://localhost:8080"
+  timeout: "60s"
+`
+		configPath := test.TempFile(t, configContent)
+		config, err := NewClientConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, NoAuthMode, config.Auth.Mode)
+
+		// Case 2: No OIDC config with auth mode "oidc" should fail
+		configContent = `
+auth:
+  mode: "oidc"
+
+server:
+  url: "http://localhost:8080"
+  timeout: "60s"
+`
+		configPath = test.TempFile(t, configContent)
+		config, err = NewClientConfig(configPath)
+		assert.Error(t, err)
+		assert.Nil(t, config)
+		assert.Contains(t, err.Error(), "OIDC issuer is required when auth.mode is 'oidc'")
+
+		// Case 3: OIDC config with auth mode "oidc" should succeed
+		configContent = `
+auth:
+  mode: "oidc"
+
+server:
+  url: "http://localhost:8080"
+  timeout: "60s"
+
+oidc:
+  issuer: "https://example.com"
+  client_id: "test-client"
+  client_secret: "test-secret"
+`
+		configPath = test.TempFile(t, configContent)
+		config, err = NewClientConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+		assert.Equal(t, OIDCAuthMode, config.Auth.Mode)
+	})
+
+	t.Run("Auth mode can be set via environment variable", func(t *testing.T) {
+		// Create a config file with default auth mode and required OIDC fields
+		configContent := `
+server:
+  url: "http://localhost:8080"
+  timeout: "60s"
+
+oidc:
+  issuer: "https://example.com"
+  client_id: "test-client"
+  client_secret: "test-secret"
+`
+		configPath := test.TempFile(t, configContent)
+
+		// Set environment variable to override auth mode
+		test.SetEnv(t, "SMCP_CLIENT_AUTH_MODE", "oidc")
+
+		// Load the config
+		config, err := NewClientConfig(configPath)
+		assert.NoError(t, err)
+		assert.NotNil(t, config)
+
+		// Verify auth mode is set to "oidc" from environment variable
+		assert.Equal(t, OIDCAuthMode, config.Auth.Mode)
+	})
+}

--- a/pkg/config/client_auth_test.go
+++ b/pkg/config/client_auth_test.go
@@ -1,10 +1,9 @@
 package config
 
 import (
+	"os"
 	"testing"
-	"time"
 
-	"github.com/ksysoev/smcp-proxy/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +21,20 @@ oidc:
   client_id: "test-client"
   client_secret: "test-secret"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "client-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
 
 		// Load the config
 		config, err := NewClientConfig(configPath)
@@ -43,7 +55,20 @@ server:
   url: "http://localhost:8080"
   timeout: "60s"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "client-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
 		config, err := NewClientConfig(configPath)
 		assert.NoError(t, err)
 		assert.NotNil(t, config)
@@ -58,7 +83,20 @@ server:
   url: "http://localhost:8080"
   timeout: "60s"
 `
-		configPath = test.TempFile(t, configContent)
+		tempFile, err = os.CreateTemp("", "client-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath = tempFile.Name()
 		config, err = NewClientConfig(configPath)
 		assert.Error(t, err)
 		assert.Nil(t, config)
@@ -78,7 +116,20 @@ oidc:
   client_id: "test-client"
   client_secret: "test-secret"
 `
-		configPath = test.TempFile(t, configContent)
+		tempFile, err = os.CreateTemp("", "client-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath = tempFile.Name()
 		config, err = NewClientConfig(configPath)
 		assert.NoError(t, err)
 		assert.NotNil(t, config)
@@ -97,10 +148,40 @@ oidc:
   client_id: "test-client"
   client_secret: "test-secret"
 `
-		configPath := test.TempFile(t, configContent)
+		tempFile, err := os.CreateTemp("", "client-config-*.yml")
+		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(tempFile.Name())
+			if err != nil {
+				t.Logf("Failed to remove temp file: %v", err)
+			}
+		}()
+		
+		_, err = tempFile.Write([]byte(configContent))
+		require.NoError(t, err)
+		require.NoError(t, tempFile.Close())
+		
+		configPath := tempFile.Name()
+
+		// Save and restore environment variables
+		oldEnv, exists := os.LookupEnv("SMCP_CLIENT_AUTH_MODE")
+		defer func() {
+			if exists {
+				err := os.Setenv("SMCP_CLIENT_AUTH_MODE", oldEnv)
+				if err != nil {
+					t.Logf("Failed to restore environment variable: %v", err)
+				}
+			} else {
+				err := os.Unsetenv("SMCP_CLIENT_AUTH_MODE")
+				if err != nil {
+					t.Logf("Failed to unset environment variable: %v", err)
+				}
+			}
+		}()
 
 		// Set environment variable to override auth mode
-		test.SetEnv(t, "SMCP_CLIENT_AUTH_MODE", "oidc")
+		err = os.Setenv("SMCP_CLIENT_AUTH_MODE", "oidc")
+		require.NoError(t, err)
 
 		// Load the config
 		config, err := NewClientConfig(configPath)

--- a/pkg/config/client_config.go
+++ b/pkg/config/client_config.go
@@ -23,6 +23,9 @@ type ClientConfig struct {
 		URL     string        `mapstructure:"url"`
 		Timeout time.Duration `mapstructure:"timeout"`
 	} `mapstructure:"server"`
+	Auth struct {
+		Mode AuthMode `mapstructure:"mode"`
+	} `mapstructure:"auth"`
 	OIDC struct {
 		Issuer        string        `mapstructure:"issuer"`
 		ClientID      string        `mapstructure:"client_id"`
@@ -82,6 +85,9 @@ func setClientDefaults(v *viper.Viper) {
 	v.SetDefault("client.write_timeout", "30s")
 	v.SetDefault("client.shutdown_timeout", "10s")
 
+	// Auth defaults - no authentication by default
+	v.SetDefault("auth.mode", string(NoAuthMode))
+
 	// Server defaults
 	v.SetDefault("server.timeout", "60s")
 
@@ -100,20 +106,23 @@ func setClientDefaults(v *viper.Viper) {
 
 // validateClientConfig validates the client configuration
 func validateClientConfig(config *ClientConfig) error {
-	// Validate required OIDC configuration
-	if config.OIDC.Issuer == "" {
-		return fmt.Errorf("OIDC issuer is required")
-	}
-	if config.OIDC.ClientID == "" {
-		return fmt.Errorf("OIDC client ID is required")
-	}
-	if config.OIDC.ClientSecret == "" {
-		return fmt.Errorf("OIDC client secret is required")
-	}
-
 	// Validate server URL
 	if config.Server.URL == "" {
 		return fmt.Errorf("server URL is required")
+	}
+
+	// Only validate OIDC configuration if OIDC auth mode is enabled
+	if config.Auth.Mode == OIDCAuthMode {
+		// Validate required OIDC configuration
+		if config.OIDC.Issuer == "" {
+			return fmt.Errorf("OIDC issuer is required when auth.mode is 'oidc'")
+		}
+		if config.OIDC.ClientID == "" {
+			return fmt.Errorf("OIDC client ID is required when auth.mode is 'oidc'")
+		}
+		if config.OIDC.ClientSecret == "" {
+			return fmt.Errorf("OIDC client secret is required when auth.mode is 'oidc'")
+		}
 	}
 
 	return nil

--- a/pkg/config/client_config_test.go
+++ b/pkg/config/client_config_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewClientConfig tests the old configuration method
-// These tests are kept for backward compatibility, but the system now
-// primarily uses direct command-line arguments and environment variables
+// TestNewClientConfig tests the client configuration
+// While the client primarily uses command-line arguments and environment variables,
+// these tests verify the configuration file behavior
 func TestNewClientConfig(t *testing.T) {
 	t.Run("Valid config file", func(t *testing.T) {
 		// Create a temporary config file

--- a/pkg/config/client_config_test.go
+++ b/pkg/config/client_config_test.go
@@ -28,6 +28,9 @@ server:
   url: "https://proxy-server.example.com"
   timeout: "45s"
 
+auth:
+  mode: "oidc"
+
 oidc:
   issuer: "https://example.com"
   client_id: "test-client"
@@ -66,6 +69,9 @@ metrics:
 		assert.Equal(t, "https://proxy-server.example.com", config.Server.URL)
 		assert.Equal(t, 45*time.Second, config.Server.Timeout)
 
+		// Verify auth mode
+		assert.Equal(t, OIDCAuthMode, config.Auth.Mode)
+
 		// Verify OIDC settings
 		assert.Equal(t, "https://example.com", config.OIDC.Issuer)
 		assert.Equal(t, "test-client", config.OIDC.ClientID)
@@ -98,6 +104,9 @@ server:
   url: "http://localhost:8080"
   timeout: "60s"
 
+auth:
+  mode: "oidc"
+
 oidc:
   issuer: "https://example.com"
   client_id: "test-client"
@@ -109,6 +118,7 @@ oidc:
 		// Set environment variables to override config
 		test.SetEnv(t, "SMCP_CLIENT_CLIENT_PORT", "9999")
 		test.SetEnv(t, "SMCP_CLIENT_SERVER_URL", "https://override.example.com")
+		test.SetEnv(t, "SMCP_CLIENT_AUTH_MODE", "none")
 
 		// Load the config
 		config, err := NewClientConfig(configPath)
@@ -118,6 +128,7 @@ oidc:
 		// Verify environment variables took precedence
 		assert.Equal(t, 9999, config.Client.Port)
 		assert.Equal(t, "https://override.example.com", config.Server.URL)
+		assert.Equal(t, NoAuthMode, config.Auth.Mode)
 	})
 
 	t.Run("Default values are set", func(t *testing.T) {
@@ -146,6 +157,7 @@ oidc:
 		assert.Equal(t, 30*time.Second, config.Client.WriteTimeout)
 		assert.Equal(t, 10*time.Second, config.Client.ShutdownTimeout)
 		assert.Equal(t, 60*time.Second, config.Server.Timeout)
+		assert.Equal(t, NoAuthMode, config.Auth.Mode) // Default auth mode is "none"
 		assert.Equal(t, []string{"openid"}, config.OIDC.Scopes)
 		assert.Equal(t, 5*time.Minute, config.OIDC.CacheTTL)
 		assert.Equal(t, 30*time.Second, config.OIDC.TokenTTLDelta)
@@ -154,76 +166,92 @@ oidc:
 		assert.Equal(t, "/metrics", config.Metrics.Path)
 	})
 
-	t.Run("Required fields validation", func(t *testing.T) {
-		// Test missing required fields one by one
-		testCases := []struct {
-			name          string
-			configContent string
-		}{
-			{
-				name: "Missing issuer",
-				configContent: `
+	t.Run("Required fields validation with auth mode", func(t *testing.T) {
+		// Test case 1: Missing server URL with both auth modes
+		configNoServerURL := `
+auth:
+  mode: "oidc"
+
+oidc:
+  issuer: "https://example.com"
+  client_id: "test-client"
+  client_secret: "test-secret"
+`
+		configPath := test.TempFile(t, configNoServerURL)
+		config, err := NewClientConfig(configPath)
+		require.Error(t, err)
+		require.Nil(t, config)
+		assert.Contains(t, err.Error(), "server URL is required")
+
+		// Test case 2: No auth or auth.mode=none doesn't require OIDC fields
+		configNoAuthNoOIDC := `
 server:
   url: "http://localhost:8080"
+
+auth:
+  mode: "none"
+`
+		configPath = test.TempFile(t, configNoAuthNoOIDC)
+		config, err = NewClientConfig(configPath)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		// Test case 3: auth.mode=oidc requires OIDC fields
+		configOIDCNoIssuer := `
+server:
+  url: "http://localhost:8080"
+
+auth:
+  mode: "oidc"
 
 oidc:
   # issuer missing
   client_id: "test-client"
   client_secret: "test-secret"
-  audience: "test-audience"
-`,
-			},
-			{
-				name: "Missing client ID",
-				configContent: `
+`
+		configPath = test.TempFile(t, configOIDCNoIssuer)
+		config, err = NewClientConfig(configPath)
+		require.Error(t, err)
+		require.Nil(t, config)
+		assert.Contains(t, err.Error(), "OIDC issuer is required when auth.mode is 'oidc'")
+
+		// Test case 4: auth.mode=oidc requires client ID
+		configOIDCNoClientID := `
 server:
   url: "http://localhost:8080"
+
+auth:
+  mode: "oidc"
 
 oidc:
   issuer: "https://example.com"
   # client_id missing
   client_secret: "test-secret"
-  audience: "test-audience"
-`,
-			},
-			{
-				name: "Missing client secret",
-				configContent: `
+`
+		configPath = test.TempFile(t, configOIDCNoClientID)
+		config, err = NewClientConfig(configPath)
+		require.Error(t, err)
+		require.Nil(t, config)
+		assert.Contains(t, err.Error(), "OIDC client ID is required when auth.mode is 'oidc'")
+
+		// Test case 5: auth.mode=oidc requires client secret
+		configOIDCNoClientSecret := `
 server:
   url: "http://localhost:8080"
+
+auth:
+  mode: "oidc"
 
 oidc:
   issuer: "https://example.com"
   client_id: "test-client"
   # client_secret missing
-  audience: "test-audience"
-`,
-			},
-			{
-				name: "Missing server URL",
-				configContent: `
-server:
-  # url missing
-  
-oidc:
-  issuer: "https://example.com"
-  client_id: "test-client"
-  client_secret: "test-secret"
-  audience: "test-audience"
-`,
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				configPath := test.TempFile(t, tc.configContent)
-
-				// Attempt to load the config
-				config, err := NewClientConfig(configPath)
-				require.Error(t, err, "Expected validation error for "+tc.name)
-				require.Nil(t, config)
-			})
-		}
+`
+		configPath = test.TempFile(t, configOIDCNoClientSecret)
+		config, err = NewClientConfig(configPath)
+		require.Error(t, err)
+		require.Nil(t, config)
+		assert.Contains(t, err.Error(), "OIDC client secret is required when auth.mode is 'oidc'")
 	})
 
 	t.Run("Invalid config file", func(t *testing.T) {
@@ -250,8 +278,4 @@ oidc:
 // Add a note to indicate this package is retained for backward compatibility
 func init() {
 	// Empty init function is kept for future backward compatibility management
-	// If you need to enable compat warnings, uncomment below:
-	// if os.Getenv("SMCP_CLIENT_COMPAT_WARNING") == "" {
-	//     fmt.Println("Warning: The client configuration package is now deprecated. The client now primarily uses command-line arguments and environment variables.")
-	// }
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -41,8 +41,21 @@ type MCPBackend struct {
 	StripPath bool          `mapstructure:"strip_path"`
 }
 
+// AuthMode defines the authentication mode
+type AuthMode string
+
+const (
+	// OIDCAuthMode uses OIDC authentication
+	OIDCAuthMode AuthMode = "oidc"
+	// NoAuthMode disables authentication
+	NoAuthMode AuthMode = "none"
+)
+
 // ServerConfig holds the configuration for the proxy server
 type ServerConfig struct {
+	Auth struct {
+		Mode AuthMode `mapstructure:"mode"`
+	} `mapstructure:"auth"`
 	OIDC struct {
 		RequiredClaims map[string]string `mapstructure:"required_claims"`
 		OptionalClaims map[string]string `mapstructure:"optional_claims"`
@@ -107,6 +120,9 @@ func setServerDefaults(v *viper.Viper) {
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "30s")
 	v.SetDefault("server.shutdown_timeout", "10s")
+
+	// Auth defaults - no authentication by default
+	v.SetDefault("auth.mode", string(NoAuthMode))
 
 	// MCP defaults
 	v.SetDefault("mcp.timeout", "60s")

--- a/pkg/proxy/client.go
+++ b/pkg/proxy/client.go
@@ -71,6 +71,7 @@ type ClientOptions struct {
 	Port              int
 	TLSEnabled        bool
 	MetricsEnabled    bool
+	AuthMode          config.AuthMode
 }
 
 // NewClient creates a new proxy client
@@ -82,17 +83,24 @@ func NewClient(
 		logger = slog.Default()
 	}
 
-	// Create the token client
-	tokenClient := auth.NewOIDCTokenClient(
-		opts.OIDCIssuer,
-		opts.OIDCClientID,
-		opts.OIDCClientSecret,
-		opts.OIDCAudience,
-		opts.OIDCScopes,
-		opts.OIDCCacheTTL,
-		opts.OIDCTokenTTLDelta,
-		logger,
-	)
+	// Create the appropriate token client based on auth mode
+	var tokenClient auth.TokenClient
+	if opts.AuthMode == config.OIDCAuthMode {
+		// Create OIDC token client
+		tokenClient = auth.NewOIDCTokenClient(
+			opts.OIDCIssuer,
+			opts.OIDCClientID,
+			opts.OIDCClientSecret,
+			opts.OIDCAudience,
+			opts.OIDCScopes,
+			opts.OIDCCacheTTL,
+			opts.OIDCTokenTTLDelta,
+			logger,
+		)
+	} else {
+		// Create no-op token client for no-auth mode
+		tokenClient = auth.NewNoAuthTokenClient()
+	}
 
 	// Create server mux
 	mux := http.NewServeMux()
@@ -181,17 +189,30 @@ func (c *Client) initRoutes() {
 	// Create the reverse proxy
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 
-	// Create transport with token authentication
-	tokenTransport := &auth.TokenTransport{
-		Base:        http.DefaultTransport,
-		Client:      c.tokenClient,
-		CacheErrors: true,
-		Logger:      c.logger,
+	var transport http.RoundTripper
+
+	// Create appropriate transport based on auth mode
+	if c.cfg.Auth.Mode == config.OIDCAuthMode {
+		// Create transport with token authentication for OIDC mode
+		tokenTransport := &auth.TokenTransport{
+			Base:        http.DefaultTransport,
+			Client:      c.tokenClient,
+			CacheErrors: true,
+			Logger:      c.logger,
+		}
+		transport = tokenTransport
+	} else {
+		// Create no-auth transport for none mode
+		noAuthTransport := &auth.NoAuthTransport{
+			Base:   http.DefaultTransport,
+			Logger: c.logger,
+		}
+		transport = noAuthTransport
 	}
 
-	// Create instrumented transport wrapping the token transport
+	// Create instrumented transport wrapping the appropriate transport
 	proxy.Transport = &clientTransport{
-		base:   tokenTransport,
+		base:   transport,
 		logger: c.logger.With("target", c.cfg.Server.URL),
 	}
 

--- a/pkg/proxy/client.go
+++ b/pkg/proxy/client.go
@@ -52,7 +52,7 @@ func (t *clientTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // ClientOptions holds options for creating a new client
 type ClientOptions struct {
-	OIDCAudience      string
+	AuthMode          config.AuthMode
 	MetricsPath       string
 	TLSKeyFile        string
 	TLSCertFile       string
@@ -61,17 +61,17 @@ type ClientOptions struct {
 	OIDCIssuer        string
 	OIDCClientID      string
 	OIDCClientSecret  string
+	OIDCAudience      string
 	OIDCScopes        []string
 	ShutdownTimeout   time.Duration
-	ServerTimeout     time.Duration
 	OIDCCacheTTL      time.Duration
 	OIDCTokenTTLDelta time.Duration
 	WriteTimeout      time.Duration
 	ReadTimeout       time.Duration
 	Port              int
+	ServerTimeout     time.Duration
 	TLSEnabled        bool
 	MetricsEnabled    bool
-	AuthMode          config.AuthMode
 }
 
 // NewClient creates a new proxy client

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -33,17 +33,25 @@ func NewServer(
 		logger = slog.Default()
 	}
 
-	// Create the token validator
-	validator, err := auth.NewOIDCTokenValidator(
-		ctx,
-		cfg.OIDC.Issuers,
-		cfg.OIDC.Audience,
-		cfg.OIDC.RequiredClaims,
-		cfg.OIDC.OptionalClaims,
-		logger,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create token validator: %w", err)
+	// Create the appropriate token validator based on auth mode
+	var validator auth.TokenValidator
+	if cfg.Auth.Mode == config.OIDCAuthMode {
+		// Create OIDC token validator
+		oidcValidator, err := auth.NewOIDCTokenValidator(
+			ctx,
+			cfg.OIDC.Issuers,
+			cfg.OIDC.Audience,
+			cfg.OIDC.RequiredClaims,
+			cfg.OIDC.OptionalClaims,
+			logger,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OIDC token validator: %w", err)
+		}
+		validator = oidcValidator
+	} else {
+		// Create no-op token validator for no-auth mode
+		validator = auth.NewNoAuthValidator()
 	}
 
 	// Create server
@@ -222,8 +230,14 @@ func (s *Server) setupBackendHandler(backend config.MCPBackend) error {
 		handler.Handle(w, r)
 	}
 
-	// Register handler with auth middleware
-	s.mux.Handle(pattern, auth.AuthMiddleware(s.validator)(http.HandlerFunc(handlerFunc)))
+	// Apply appropriate middleware based on auth mode
+	if s.cfg.Auth.Mode == config.OIDCAuthMode {
+		// Apply auth middleware for OIDC mode
+		s.mux.Handle(pattern, auth.AuthMiddleware(s.validator)(http.HandlerFunc(handlerFunc)))
+	} else {
+		// Apply no-auth middleware for none mode
+		s.mux.Handle(pattern, auth.NoAuthMiddleware(http.HandlerFunc(handlerFunc)))
+	}
 
 	return nil
 }

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -70,12 +70,19 @@ func TestServerSetupBackendHandler(t *testing.T) {
 		validateClaims: jwt.MapClaims{"sub": "test-user"},
 	}
 
-	// Create server with mock validator
+	// Create server with mock validator and config
 	server := &Server{
 		logger:    logger,
 		validator: mockValidator,
 		mux:       http.NewServeMux(),
 		backends:  make(map[string]MCPBackendHandler),
+		cfg: &config.ServerConfig{
+			Auth: struct {
+				Mode config.AuthMode "mapstructure:\"mode\""
+			}{
+				Mode: config.NoAuthMode, // Default to no-auth mode for the test
+			},
+		},
 	}
 
 	// Create a test backend


### PR DESCRIPTION
## Summary
- Add no-auth validator and token client implementations that skip authentication
- Make authentication mode configurable with an `auth.mode` setting ("none" or "oidc")
- Set no-auth as the default authentication mode for easier setup and testing
- Update client and server commands to support `--auth-mode` flag

## Test plan
1. Run server with no auth: `./smcp-proxy server --config=configs/proxy-server.yml`
2. Run client with no auth: `./smcp-proxy client --server-url="http://localhost:8080"`
3. Verify connections work without authentication
4. Run server with OIDC: `./smcp-proxy server --config=configs/proxy-server.yml --auth-mode=oidc`
5. Run client with OIDC: `./smcp-proxy client --auth-mode=oidc --server-url="http://localhost:8080" --oidc-issuer="https://your-issuer.com" --oidc-client-id="your-id" --oidc-client-secret="your-secret"`
6. Verify OIDC authentication works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)