### PR TITLE
Add Memory MCP server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ The server configuration still uses YAML files and can be overridden using envir
 ./smcp-proxy server --config=configs/proxy-server.yml --auth-mode=oidc --log-level=debug
 ```
 
+### Examples
+
+For complete working examples, see the [examples directory](./examples):
+- [Memory MCP Server Example](./examples/memory) - Shows how to set up SMCP Proxy with a Memory MCP server
+
 ### Starting the Client
 
 #### Without Authentication (Default)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,34 @@
+# SMCP Proxy Examples
+
+This directory contains practical examples for using SMCP Proxy in various scenarios.
+
+## Available Examples
+
+### [Memory MCP](./memory)
+
+A complete example demonstrating how to use SMCP Proxy with a Memory MCP server. This setup allows:
+- Creation and management of memory sessions
+- Storing and retrieving conversation history
+- Integration with LLMs that need conversation context
+
+The example includes:
+- Docker Compose configuration
+- Server configuration
+- Test script
+- Detailed instructions with curl examples
+
+## Running the Examples
+
+Each example directory contains its own README with specific instructions. The examples use Docker Compose for ease of setup and testing.
+
+## Creating Your Own Examples
+
+To create your own SMCP Proxy setup:
+
+1. Start with the server configuration (modify an existing `server.yml`)
+2. Configure one or more MCP backends
+3. Choose the appropriate transport (HTTP or stdio)
+4. Select the authentication mode (none or OIDC)
+5. Launch both the server and client components
+
+Refer to the main [README](../README.md) for detailed configuration options.

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,0 +1,195 @@
+# Memory MCP Server Example
+
+This example demonstrates how to set up SMCP Proxy with a Memory MCP server. The Memory MCP server provides conversation history retention capabilities, allowing LLM applications to retrieve and update conversation state.
+
+## Architecture
+
+```
+┌───────────────┐      ┌───────────────┐      ┌───────────────┐      ┌───────────────┐
+│  Application  │      │ SMCP Client   │      │ SMCP Server   │      │   Memory MCP  │
+│  (curl/apps)  │──────│ at :8081      │──────│ at :8080      │──────│   Server      │
+└───────────────┘      └───────────────┘      └───────────────┘      └───────────────┘
+                                                                       │
+                                                                       │ 
+                                                                       ▼
+                                                                    ┌─────────┐
+                                                                    │ Volume  │
+                                                                    │ Storage │
+                                                                    └─────────┘
+```
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Basic understanding of HTTP APIs
+- Free ports 8080 and 8081 on your host machine
+
+## Setup
+
+1. Navigate to this example directory:
+   ```bash
+   cd examples/memory
+   ```
+
+2. Start the Docker Compose stack:
+   ```bash
+   docker-compose up -d
+   ```
+
+3. Check that all services are running:
+   ```bash
+   docker-compose ps
+   ```
+
+## Configuration
+
+The setup includes:
+
+1. **Memory MCP Server**: Runs the official Memory MCP server container
+2. **SMCP Proxy Server**: Connects to the Memory MCP server and exposes it at `/v1/memory/*`
+3. **SMCP Proxy Client**: Provides an unauthenticated endpoint for applications
+
+The server configuration (`configs/server.yml`) is set up for HTTP transport to communicate with the Memory MCP server running as a separate container.
+
+## Testing the Setup
+
+### Check Available Models
+
+First, verify that the SMCP Proxy is correctly exposing the Memory MCP server:
+
+```bash
+curl http://localhost:8081/api/models | jq
+```
+
+You should see output similar to:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "ID": "memory",
+      "Name": "Memory",
+      "Model": "memory",
+      "MaxTokens": 100000,
+      "Path": "/v1/memory"
+    }
+  ]
+}
+```
+
+### Health Checks
+
+Verify that both the client and server are healthy:
+
+```bash
+curl http://localhost:8081/health
+curl http://localhost:8080/health
+```
+
+Both should return `OK`.
+
+### Creating a Memory Session
+
+Create a new memory session:
+
+```bash
+curl -X POST http://localhost:8081/v1/memory/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "test-session",
+    "metadata": {
+      "user_id": "test-user",
+      "description": "Test memory session"
+    }
+  }'
+```
+
+You should receive a response confirming the session creation.
+
+### Adding Messages to Memory
+
+Add a message to the memory session:
+
+```bash
+curl -X POST http://localhost:8081/v1/memory/sessions/test-session/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": "Hello, can you remember this message?"
+  }'
+```
+
+Add an assistant response:
+
+```bash
+curl -X POST http://localhost:8081/v1/memory/sessions/test-session/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "assistant",
+    "content": "Yes, I will remember this message."
+  }'
+```
+
+### Retrieving Memory
+
+Get all messages from the session:
+
+```bash
+curl http://localhost:8081/v1/memory/sessions/test-session/messages | jq
+```
+
+You should see both messages you added.
+
+### Updating Metadata
+
+Update session metadata:
+
+```bash
+curl -X PATCH http://localhost:8081/v1/memory/sessions/test-session \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "user_id": "test-user",
+      "description": "Updated memory session description"
+    }
+  }'
+```
+
+### Listing Sessions
+
+List all available sessions:
+
+```bash
+curl http://localhost:8081/v1/memory/sessions | jq
+```
+
+## Real-world Integration
+
+To integrate this with an LLM application:
+
+1. Configure your LLM application to use the Memory MCP endpoint at `http://localhost:8081/v1/memory`
+2. Create a session for each user or conversation
+3. Before each LLM request, retrieve the conversation history
+4. After each LLM request, store the new messages
+
+## Cleanup
+
+To stop all services and remove containers:
+
+```bash
+docker-compose down
+```
+
+To completely clean up, including the persistent volume:
+
+```bash
+docker-compose down -v
+```
+
+## Troubleshooting
+
+- **Client can't connect to server**: Check that the server is running and ports are correct
+- **Server can't connect to Memory MCP**: Check Docker network connectivity
+- **HTTP 404 errors**: Ensure you're using the correct path prefix (/v1/memory)
+- **Data not persisting**: Check the Docker volume is mounted correctly

--- a/examples/memory/configs/server.yml
+++ b/examples/memory/configs/server.yml
@@ -1,0 +1,32 @@
+server:
+  host: "0.0.0.0"
+  port: 8080
+  read_timeout: "30s"
+  write_timeout: "30s"
+  shutdown_timeout: "10s"
+
+# Authentication configuration (default: none)
+auth:
+  # Mode can be "none" or "oidc"
+  mode: "none"
+
+mcp:
+  # Global timeout for all backends
+  timeout: "60s"
+  
+  # Configure the Memory MCP backend
+  backends:
+    # Memory MCP server
+    - id: "memory"
+      name: "Memory"
+      model: "memory"
+      max_tokens: 100000
+      transport: "http"
+      url: "http://memory-mcp:3000"
+      path: "/v1/memory"
+      strip_path: true
+      timeout: "60s"
+
+metrics:
+  enabled: true
+  path: "/metrics"

--- a/examples/memory/docker-compose.yml
+++ b/examples/memory/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  # Memory MCP Server
+  memory-mcp:
+    image: ghcr.io/anthropic-labs/mcp/memory:latest
+    volumes:
+      - memory-data:/app/dist
+    networks:
+      - mcp-network
+    restart: unless-stopped
+
+  # SMCP Proxy Server
+  smcp-server:
+    image: ghcr.io/ksysoev/smcp-proxy:main
+    command: ["server", "--config=/app/configs/server.yml", "--log-level=debug"]
+    volumes:
+      - ./configs:/app/configs
+    ports:
+      - "8080:8080"
+    networks:
+      - mcp-network
+    depends_on:
+      - memory-mcp
+    restart: unless-stopped
+
+  # SMCP Proxy Client
+  smcp-client:
+    image: ghcr.io/ksysoev/smcp-proxy:main
+    command: ["client", "--server-url=http://smcp-server:8080", "--log-level=debug"]
+    ports:
+      - "8081:8081"
+    networks:
+      - mcp-network
+    depends_on:
+      - smcp-server
+    restart: unless-stopped
+
+networks:
+  mcp-network:
+    driver: bridge
+
+volumes:
+  memory-data:

--- a/examples/memory/test.sh
+++ b/examples/memory/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+echo "Starting SMCP Proxy with Memory MCP..."
+docker-compose up -d
+
+echo "Waiting for services to be ready..."
+sleep 5
+
+echo "Checking service health..."
+echo "SMCP Client: $(curl -s http://localhost:8081/health)"
+echo "SMCP Server: $(curl -s http://localhost:8080/health)"
+
+echo -e "\nChecking available models..."
+curl -s http://localhost:8081/api/models | jq
+
+echo -e "\nCreating a memory session..."
+curl -s -X POST http://localhost:8081/v1/memory/sessions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "session_id": "test-session",
+    "metadata": {
+      "user_id": "test-user",
+      "description": "Test memory session"
+    }
+  }' | jq
+
+echo -e "\nAdding user message to memory..."
+curl -s -X POST http://localhost:8081/v1/memory/sessions/test-session/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "user",
+    "content": "Hello, can you remember this message?"
+  }' | jq
+
+echo -e "\nAdding assistant message to memory..."
+curl -s -X POST http://localhost:8081/v1/memory/sessions/test-session/messages \
+  -H "Content-Type: application/json" \
+  -d '{
+    "role": "assistant",
+    "content": "Yes, I will remember this message."
+  }' | jq
+
+echo -e "\nRetrieving all messages from memory..."
+curl -s http://localhost:8081/v1/memory/sessions/test-session/messages | jq
+
+echo -e "\nListing all sessions..."
+curl -s http://localhost:8081/v1/memory/sessions | jq
+
+echo -e "\nTest completed successfully!"
+echo "To stop the services, run: docker-compose down"


### PR DESCRIPTION
## Summary
- Create example directory with Memory MCP server setup
- Add Docker Compose configuration for easy deployment
- Include detailed README with step-by-step instructions
- Provide sample curl commands for testing functionality
- Add test script for automated verification

## Test plan
1. Navigate to the  directory
2. Run  to start the services
3. Execute the test script: 
4. Verify all operations complete successfully
5. Run  to clean up

This example provides a complete working demonstration of SMCP Proxy with a Memory MCP server, including:
- How to set up the proper configuration
- How to route requests to specific backends
- How to interact with the Memory API
- Best practices for deployment

🤖 Generated with [Claude Code](https://claude.ai/code)